### PR TITLE
Fixed a bug when doing jovo deploy

### DIFF
--- a/01_helloworld/javascript/package.json
+++ b/01_helloworld/javascript/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "tsc": "node -v",
     "test": "jest",
-    "bundle": "gulp --gulpfile node_modules/jovo-framework/gulpfile.js --cwd ..",
+    "bundle": "gulp --gulpfile node_modules/jovo-framework/gulpfile.js --cwd .",
     "start": "cd src && node index.js --webhook",
     "launch": "npm start -- --launch"
   },


### PR DESCRIPTION
Hey,

I recently created a fresh Jovo project with this template. I found an issue when I ran `jovo deploy`. When I removed one of the dots from the two dots in the `npm run bundle` command, I found that it fixed it.

I created a forum post for the issue which I [updated with the fix](https://community.jovo.tech/t/deploying-skill-not-working/242).